### PR TITLE
Window Switcher: by default show items only from the current workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Supported GNOME versions
 
-- 42-44
+- 40-44
 - 45
 
 ## Installation

--- a/alttab-mod@leleat-on-github/schemas/org.gnome.shell.extensions.altTab-mod.gschema.xml
+++ b/alttab-mod@leleat-on-github/schemas/org.gnome.shell.extensions.altTab-mod.gschema.xml
@@ -8,7 +8,7 @@
 			<default>false</default>
 		</key>
 		<key name="current-workspace-only-window" type="b">
-			<default>false</default>
+			<default>true</default>
 		</key>
 		<key name="current-monitor-only-window" type="b">
 			<default>false</default>


### PR DESCRIPTION
It's a default setting for GNOME, as well as for distributions that bind Window Switcher to Alt+Tab.