### PR TITLE
Port to 46

### DIFF
--- a/alttab-mod@leleat-on-github/extension.js
+++ b/alttab-mod@leleat-on-github/extension.js
@@ -459,7 +459,7 @@ export default class AltTabModExtension extends Extension {
                     this._haveModal = true;
                     this._modifierMask = primaryModifier(mask);
 
-                    this.add_actor(this._switcherList);
+                    this.add_child(this._switcherList);
                     this._switcherList.connect(
                         'item-activated',
                         this._itemActivated.bind(this)

--- a/alttab-mod@leleat-on-github/metadata.json
+++ b/alttab-mod@leleat-on-github/metadata.json
@@ -3,7 +3,7 @@
   "description": "Add some QoL changes to the App Switcher (Alt/Super+Tab)...\n- use `WASD`, `hjkl` or the arrow keys for navigation\n- `Q` only closes the selected window instead of the entire app\n- only raise the first window instead of every instance\n- optionally: only show windows from the current workspace\n- optionally: only show windows from the current monitor\n- optionally: remove the App Switcher's delayed appearance",
   "name": "AltTab Mod",
   "shell-version": [
-    "45"
+    "46"
   ],
   "url": "https://github.com/Leleat/AltTab-Mod",
   "uuid": "alttab-mod@leleat-on-github",


### PR DESCRIPTION
This might be the only change necessary to port the extension to Gnome 46. I, however, did not test it thoroughly enough to state that with absolute certainty.