### PR TITLE
Initial support for Gnome 50

### DIFF
--- a/alttab-mod@leleat-on-github/extension.js
+++ b/alttab-mod@leleat-on-github/extension.js
@@ -446,16 +446,7 @@ export default class AltTabModExtension extends Extension {
                         return false;
                     }
 
-                    const grab = Main.pushModal(this);
-                    // We expect at least a keyboard grab here
-                    if (
-                        (grab.get_seat_state() & Clutter.GrabState.KEYBOARD) ===
-                        0
-                    ) {
-                        Main.popModal(grab);
-                        return false;
-                    }
-                    this._grab = grab;
+                    this._grab = Main.pushModal(this);
                     this._haveModal = true;
                     this._modifierMask = primaryModifier(mask);
 

--- a/alttab-mod@leleat-on-github/metadata.json
+++ b/alttab-mod@leleat-on-github/metadata.json
@@ -3,7 +3,7 @@
   "description": "Add some QoL changes to the App Switcher (Alt/Super+Tab)...\n- use `WASD`, `hjkl` or the arrow keys for navigation\n- `Q` only closes the selected window instead of the entire app\n- only raise the first window instead of every instance\n- optionally: only show windows from the current workspace\n- optionally: only show windows from the current monitor\n- optionally: remove the App Switcher's delayed appearance",
   "name": "AltTab Mod",
   "shell-version": [
-    "46", "47", "48", "49"
+    "50"
   ],
   "url": "https://github.com/Leleat/AltTab-Mod",
   "uuid": "alttab-mod@leleat-on-github",


### PR DESCRIPTION
Grabs appears to be unfailable now, so a check is no longer needed. This makes this version not compatible with previous versions of gnome, but EGO will continue serving older builds to users of older Gnome.

This is a minimal change necessary to make this extension work on Gnome 50. I haven't tested every feature available, only the ones I use.